### PR TITLE
Remove unicode() call

### DIFF
--- a/queue_fetcher/tasks/base.py
+++ b/queue_fetcher/tasks/base.py
@@ -96,7 +96,7 @@ class QueueFetcher(object):
                     q_message = json.loads(q_message)
                 self.process(q_message)
         except MessageError as ex:
-            logger.error(str(ex))
+            logger.error(six.text_type(ex))
             logger.info('Message could not be processed')
         else:
             rsp = True

--- a/queue_fetcher/tasks/base.py
+++ b/queue_fetcher/tasks/base.py
@@ -1,5 +1,7 @@
 """Base classes for background tasks
 """
+from __future__ import unicode_literals
+
 import logging
 import json
 from datetime import datetime
@@ -94,7 +96,7 @@ class QueueFetcher(object):
                     q_message = json.loads(q_message)
                 self.process(q_message)
         except MessageError as ex:
-            logger.error(unicode(ex))
+            logger.error(str(ex))
             logger.info('Message could not be processed')
         else:
             rsp = True


### PR DESCRIPTION
This PR fixes a `NameError` being triggered when calling a task under Python 3