### PR TITLE
Fix calling send_message with bytes under Python 3

### DIFF
--- a/queue_fetcher/utils/sqs.py
+++ b/queue_fetcher/utils/sqs.py
@@ -116,24 +116,20 @@ def send_message(queue, message, raise_exception=True):
     except AttributeError:
         raise ImproperlyConfigured(SQS_NOT_SETUP)
 
-    is_text = (
-        isinstance(message, six.string_types)
-        or isinstance(message, six.binary_type)
-    )
+    if isinstance(message, six.binary_type):
+        message = message.decode('utf-8')
+
+    is_text = isinstance(message, six.string_types)
 
     if test_sqs:
         # Test Mode: Don't even try and send it!
         if is_text:
-            if isinstance(message, six.binary_type):
-                message = message.decode('utf-8')
-
             message = json.loads(message)
 
         if queue.name not in outbox:
             outbox[queue.name] = []
         outbox[queue.name].append(message)
-        logger.info('New message on queue %s: %s',
-                    queue.name, six.text_type(message))
+        logger.info('New message on queue %s: %s', queue.name, message)
     else:
         if not is_text:
             message = json.dumps(message)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ except Exception:
 
 setup(
     name='queue-fetcher',
-    version='2.0.8',
+    version='2.0.9',
     description="QueueFetcher makes dealing with SQS queues in Django easier",
     author="SF Software limited t/a Pebble",
     author_email="sysadmin@mypebble.co.uk",


### PR DESCRIPTION
This PR fixes an error when calling send_message with a byte string under Python 3. I have added additional tests for the case where `TEST_SQS = False`.